### PR TITLE
Revert to simple recipe for log stacking 

### DIFF
--- a/Contents/mods/Hydrocraft/media/scripts/Carpentry.txt
+++ b/Contents/mods/Hydrocraft/media/scripts/Carpentry.txt
@@ -1578,42 +1578,12 @@ recipe Make Wooden Pallet
         OnGiveXP:HCWoodwork_OnGiveXP,
     }
 
-
-    recipe Make Two-Log Stack
-    {
-        Log=2,
-        [Recipe.GetItemTypes.CraftLogStack]=2,
-        Result:LogStacks2,
-        Time:60.0,
-		override:true,
-        CanBeDoneFromFloor:true,
-        Category:Carpentry,
-        OnCreate:Recipe.OnCreate.CreateLogStack,
-        OnGiveXP:Recipe.OnGiveXP.None,
-        Sound:LogAddToStack,
-    }
-
-    recipe Make Three-Log Stack
-    {
-        Log=3,
-        [Recipe.GetItemTypes.CraftLogStack]=2,
-        Result:LogStacks3,
-        Time:60.0,
-		override:true,
-        CanBeDoneFromFloor:true,
-        OnCreate:Recipe.OnCreate.CreateLogStack,
-        Category:Carpentry,
-        OnGiveXP:Recipe.OnGiveXP.None,
-        Sound:LogAddToStack,
-    }
-
-    recipe Make Four-Log Stack
+    recipe Make Four-Log Stack on the Floor
     {
         Log=4,
         [Recipe.GetItemTypes.CraftLogStack]=2,
         Result:LogStacks4,
         Time:60.0,
-		override:true,
         CanBeDoneFromFloor:true,
         OnCreate:Recipe.OnCreate.CreateLogStack,
         Category:Carpentry,
@@ -1621,38 +1591,11 @@ recipe Make Wooden Pallet
         Sound:LogAddToStack,
     }
 
-    recipe Unstack Logs
-    {
-        LogStacks2,
-        Result:Log=2,
-        Time:60.0,
-		override:true,
-        CanBeDoneFromFloor:true,
-        OnCreate:Recipe.OnCreate.SplitLogStack,
-        Category:Carpentry,
-        OnGiveXP:Recipe.OnGiveXP.None,
-        Sound:LogRemoveFromStack,
-    }
-
-    recipe Unstack Logs
-    {
-        LogStacks3,
-        Result:Log=3,
-        Time:60.0,
-		override:true,
-        CanBeDoneFromFloor:true,
-        OnCreate:Recipe.OnCreate.SplitLogStack,
-        Category:Carpentry,
-        OnGiveXP:Recipe.OnGiveXP.None,
-        Sound:LogRemoveFromStack,
-    }
-
-    recipe Unstack Logs
+    recipe Unstack Logs on the Floor
     {
         LogStacks4,
         Result:Log=4,
         Time:60.0,
-		override:true,
         CanBeDoneFromFloor:true,
         OnCreate:Recipe.OnCreate.SplitLogStack,
         Category:Carpentry,
@@ -1668,7 +1611,7 @@ recipe Pack Lumber Stack
         Time:40.0,
         CanBeDoneFromFloor:true,
         Category:Carpentry,
-    OnGiveXP:HCNoExpGain,
+		OnGiveXP:HCNoExpGain,
     }
 
 recipe Unpack Lumber Stack


### PR DESCRIPTION
Revert to simple recipe for log stacking
 -> overwrite doesn't provide consistent results to overwrite base recipes