### PR TITLE
Update Mining.txt

### DIFF
--- a/Contents/mods/Hydrocraft/media/scripts/Mining.txt
+++ b/Contents/mods/Hydrocraft/media/scripts/Mining.txt
@@ -992,8 +992,8 @@ recipe Mine
 
 recipe Mine Iron
     {
-        keep HCIronMineB,
         keep Shovel/Shovel2/PickAxe,
+	keep HCIronMineB,
         CanBeDoneFromFloor:true,
         Result:HCIronore,
         NeedToBeLearn:true,
@@ -1004,8 +1004,8 @@ recipe Mine Iron
 
 recipe Mine Coal
     {
-        keep HCCoalMineB,
         keep Shovel/Shovel2/PickAxe,
+	keep HCCoalMineB,
         CanBeDoneFromFloor:true,
         Result:HCCoal,
         NeedToBeLearn:true,


### PR DESCRIPTION
I adjusted the recipe for "mine coal" and "mine iron" so that the tools appear first in the list. Currently even if you have the tool in your inventory if you select mine "all" the second and all subsequent ores appear on the ground because of the order they appear in the recipe. I'm making my own recipe but this just adds a lot of time if you're mining a lot of items, like for example if you need a ton of steel to make a green house.