### PR TITLE
Concrete Compatibility and Bug fix

### DIFF
--- a/Contents/mods/Hydrocraft/media/lua/server/Items/Distributions_HC.lua
+++ b/Contents/mods/Hydrocraft/media/lua/server/Items/Distributions_HC.lua
@@ -4,7 +4,7 @@ HCSprites = {}
 
 SuburbsDistributions = SuburbsDistributions or {}
 
-local funtion insertInto(table1, table2)
+local function insertInto(table1, table2)
 	for k,v in pairs(table2) do
 		table.insert(table1, v)
 	end

--- a/Contents/mods/Hydrocraft/media/lua/server/Recipe_GetItemTypes.lua
+++ b/Contents/mods/Hydrocraft/media/lua/server/Recipe_GetItemTypes.lua
@@ -88,3 +88,7 @@ end
 function Recipe.GetItemTypes.Shit(scriptItems)
 	scriptItems:addAll(getScriptManager():getItemsTag("Shit"))
 end
+
+function Recipe.GetItemTypes.BucketConcrete(scriptItems)
+	scriptItems:addAll(getScriptManager():getItemsTag("BucketConcrete"))
+end

--- a/Contents/mods/Hydrocraft/media/lua/shared/ModifyBaseItems.lua
+++ b/Contents/mods/Hydrocraft/media/lua/shared/ModifyBaseItems.lua
@@ -519,7 +519,10 @@ if scriptItem then
 	scriptItem:DoParam("NylonAmount = 4")
 end
 
-
+scriptItem = ScriptManager.instance:getItem("Base.BucketConcreteFull")
+if scriptItem then
+	scriptItem:DoParam("Tags = BucketConcrete")
+end
 
 
 

--- a/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Fishing.txt
+++ b/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Fishing.txt
@@ -409,7 +409,7 @@ recipe Dig Fish Pond
 recipe Fill Pond Hole with Cement
     {
 	HCPondholedirt,
-    	HCWoodenbucketconcrete=8,
+    	[Recipe.GetItemTypes.BucketConcrete]=8,
     	keep HCMasontrowel,
     	CanBeDoneFromFloor:true,
     	Result:HCPondholecement,

--- a/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Industrial.txt
+++ b/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Industrial.txt
@@ -781,7 +781,7 @@ recipe Build Industrial Furnace
     {
 	SkillRequired:Mechanics=5,
         HCGreybrickbox,
-    	HCWoodenbucketconcrete=4,
+    	[Recipe.GetItemTypes.BucketConcrete]=4,
         Screws=10,
         HCLargesheetmetal=2,
         SheetMetal=4,
@@ -808,7 +808,7 @@ recipe Upgrade to Industrial Furnace
     {
         SkillRequired:Mechanics=5,
         HCGreybrickbox,
-        HCWoodenbucketconcrete=4,
+        [Recipe.GetItemTypes.BucketConcrete]=4,
         HCBlastfurnace/HCBlastfurnace2,
         Screws=10,
         HCLargesheetmetal=2,

--- a/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Masonry.txt
+++ b/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Masonry.txt
@@ -205,7 +205,7 @@ recipe Make Concrete Ingot
 
 recipe Make Concrete Block
     {
-	HCWoodenbucketconcrete,
+	[Recipe.GetItemTypes.BucketConcrete],
     	HCBlockmold,
     	CanBeDoneFromFloor:true,
     	Result:HCConcreteblock,
@@ -218,7 +218,7 @@ recipe Make Concrete Block
 recipe Make Hempcrete Block
     {
 	HCPlantfibers=3,
-	HCWoodenbucketconcrete,
+	[Recipe.GetItemTypes.BucketConcrete],
     	HCBlockmold,
     	CanBeDoneFromFloor:true,
     	Result:HCHempcreteblock,
@@ -231,7 +231,7 @@ recipe Make Hempcrete Block
 recipe Make Leadcrete Block
     {
 	HCLeadpowder=3,
-	HCWoodenbucketconcrete,
+	[Recipe.GetItemTypes.BucketConcrete],
     	HCBlockmold,
     	CanBeDoneFromFloor:true,
     	Result:HCLeadcreteblock,

--- a/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Metalurgy.txt
+++ b/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Metalurgy.txt
@@ -509,7 +509,7 @@ item HCCannonball
 recipe Make Smelter
     {
     	HCRedbrick=50,
-    	HCWoodenbucketconcrete=4,
+    	[Recipe.GetItemTypes.BucketConcrete]=4,
     	keep HCMasontrowel,
     	CanBeDoneFromFloor:true,
     	Result:HCSmelter,
@@ -557,7 +557,7 @@ recipe Make Bellows
 recipe Make Blast Furnace
     {
     	HCRedbrickbox,
-    	HCWoodenbucketconcrete=8,
+    	[Recipe.GetItemTypes.BucketConcrete]=8,
     	HCRopethick,
     	HCPully/HCPullyiron/HCPullywood,
     	Bellows,
@@ -609,7 +609,7 @@ recipe Upgrade to Blast Furnace
     {
         HCRedbrick=50,
         HCSmelter/HCSmelter2,
-        HCWoodenbucketconcrete=8,
+	   [Recipe.GetItemTypes.BucketConcrete]=8,
         HCRopethick,
         HCPully/HCPullyiron/HCPullywood,
         Bellows,

--- a/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Stoneworking.txt
+++ b/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Stoneworking.txt
@@ -225,8 +225,9 @@ item HCWoodenbucketconcrete
 	DisplayName		=	Wooden Bucket with Concrete,
 	ReplaceOnDeplete	=	HCWoodenbucket,
 	Icon			=	HCWoodenbucketconcrete,
-		DisplayCategory	= CraftMas,
-	
+	DisplayCategory	= CraftMas,
+	Tags 			= 	BucketConcrete,
+		
 	}
 
 item HCCellar
@@ -291,7 +292,7 @@ recipe Construct Cellar
     {
     	HCMinehole,
 	HCStonepilebox=4,
-    	HCWoodenbucketconcrete=4,
+    	[Recipe.GetItemTypes.BucketConcrete]=4,
 	HCWoodbeam=4,
 	HCLumberstack,
 	HCSteelrod,
@@ -338,7 +339,7 @@ recipe Construct Tar Kiln
     {
     HCWoodenbucket,
     Stone=50,
-    HCWoodenbucketconcrete=4,
+    [Recipe.GetItemTypes.BucketConcrete]=4,
     keep HCMasontrowel,
     CanBeDoneFromFloor:true,
     Result:HCTarkiln,
@@ -352,7 +353,7 @@ recipe Construct Tar Kiln
     {
     HCWoodenbucket,
     SharpedStone=75,
-    HCWoodenbucketconcrete=4,
+    [Recipe.GetItemTypes.BucketConcrete]=4,
     keep HCMasontrowel,
     CanBeDoneFromFloor:true,
     Result:HCTarkiln,
@@ -383,7 +384,7 @@ recipe Construct Well
     	HCWoodenbucket,
 	HCCrank/HCCrankiron,
     	HCStonepilebox=3,
-    	HCWoodenbucketconcrete=8,
+    	[Recipe.GetItemTypes.BucketConcrete]=8,
     	Plank=3,
     	HCRopethick,
     	HCMinehole,
@@ -541,7 +542,7 @@ recipe Construct Oil Press
     	Stone=25,
     	Log=2,
     	HCStonewheel=2,
-    	HCWoodenbucketconcrete=4,
+    	[Recipe.GetItemTypes.BucketConcrete]=4,
     	CanBeDoneFromFloor:true,
     	Result:HCOilpress,
     	NeedToBeLearn:true,
@@ -609,7 +610,7 @@ recipe Make Stone Wheel
 recipe Construct Grindstone
     {
     	Stone=20,
-    	HCWoodenbucketconcrete=4,
+    	[Recipe.GetItemTypes.BucketConcrete]=4,
     	Result:HCGrindstone,
     	NeedToBeLearn:true,
     	Time:400,
@@ -635,7 +636,7 @@ recipe Build Stamp Mill
         Screws=16,
 	HCWoodbeam=2,
     	Plank=4,
-    	HCWoodenbucketconcrete=4,
+    	[Recipe.GetItemTypes.BucketConcrete]=4,
         SheetMetal=2,
 	HCSteelrod=5,
 	HCSteelingot=5,


### PR DESCRIPTION
Adds new tag BucketConcrete,
Adds new function to incorporate BucketConcrete,
Adds HCWoodenBucketConcrete And Base.BucketConcreteFull to the tag,
and changes every recipe to allow to use the new tag

Fixes Bug report: Syntax Errors in Distributions_HC.lua 
and most likely will fix farmers not dropping packets of unknown seeds among other things
 https://discord.com/channels/963714784564498442/1108969222249394276