### PR TITLE
Update HC_Smithing.txt Changed Steel Pipe to go on the back slot.

### DIFF
--- a/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Smithing.txt
+++ b/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Smithing.txt
@@ -749,6 +749,7 @@ item HCTinsheetbox
 		BreakSound  			=   	BreakMetalItem,
 		TreeDamage  			=   	1,
 	DisplayCategory		=	CraftMet,
+        AttachmentType = BigWeapon,
 	}
 
 /************************RECIPES************************/


### PR DESCRIPTION
Added "AttachmentType = BigWeapon," to Line 752 which is at the bottom of the description for the steel pipe, as was requested by Hugo Qwerty after I inquired about the steel pipe not going onto the hot bar anywhere.

Thanks.